### PR TITLE
Add quasi-quoter

### DIFF
--- a/burrito.cabal
+++ b/burrito.cabal
@@ -31,11 +31,16 @@ source-repository head
   location: https://github.com/tfausak/burrito
   type: git
 
+flag TemplateHaskell
+  description: Enable template-haskell support
+  default: True
+
 library
   build-depends:
     base >= 4.12.0 && < 4.15
   default-language: Haskell98
   exposed-modules: Burrito
+  extensions: CPP
   ghc-options:
     -Weverything
     -Wno-all-missed-specialisations
@@ -53,6 +58,12 @@ library
       -Wno-missing-safe-haskell-mode
       -Wno-prepositive-qualified-module
 
+  if flag(TemplateHaskell)
+    build-depends: template-haskell >= 2.14 && < 12.16
+    exposed-modules: Burrito.QQ, Burrito.TH
+    extensions: DeriveLift, StandaloneDeriving
+    cpp-options: -DTemplateHaskell
+
 test-suite test
   build-depends:
     base -any
@@ -60,6 +71,11 @@ test-suite test
     , HUnit >= 1.6.0 && < 1.7
     , transformers >= 0.5.6 && < 0.6
   default-language: Haskell98
+  extensions: CPP
   hs-source-dirs: src/test
   main-is: Main.hs
   type: exitcode-stdio-1.0
+
+  if flag(TemplateHaskell)
+    cpp-options: -DTemplateHaskell
+    extensions: QuasiQuotes

--- a/src/lib/Burrito.hs
+++ b/src/lib/Burrito.hs
@@ -48,6 +48,9 @@ import qualified Data.Maybe as Maybe
 import qualified Data.Word as Word
 import qualified Text.Printf as Printf
 
+#ifdef TemplateHaskell
+import qualified Language.Haskell.TH.Syntax as TH
+#endif
 
 -- | Attempts to parse a string as a URI template. If parsing fails, this will
 -- return 'Nothing'. Otherwise it will return 'Just' the parsed template.
@@ -942,3 +945,16 @@ between
   -> a
   -> Bool
 between lo hi x = lo <= x && x <= hi
+
+#ifdef TemplateHaskell
+-- Derived Lift instance for Template Haskell
+deriving instance TH.Lift Character
+deriving instance TH.Lift Expression
+deriving instance TH.Lift Literal
+deriving instance TH.Lift Modifier
+deriving instance TH.Lift Name
+deriving instance TH.Lift Operator
+deriving instance TH.Lift Template
+deriving instance TH.Lift Token
+deriving instance TH.Lift Variable
+#endif

--- a/src/lib/Burrito/QQ.hs
+++ b/src/lib/Burrito/QQ.hs
@@ -1,0 +1,18 @@
+module Burrito.QQ ( uriTemplate ) where
+
+import qualified Burrito
+import qualified Burrito.TH
+import qualified Language.Haskell.TH.Quote as Q
+
+import Language.Haskell.TH.Syntax (Q)
+
+uriTemplate :: Q.QuasiQuoter
+uriTemplate = Q.QuasiQuoter
+  { Q.quoteExp  = maybe invalid Burrito.TH.templateExpression . Burrito.parse
+  , Q.quotePat  = maybe invalid Burrito.TH.templatePattern . Burrito.parse
+  , Q.quoteType = \_ -> fail "uriTemplate cannot be used in a type context"
+  , Q.quoteDec  = \_ -> fail "uriTemplate cannot be used in a declaration context"
+  }
+  where
+    invalid :: Q a
+    invalid = fail "Invalid URI template expression"

--- a/src/lib/Burrito/TH.hs
+++ b/src/lib/Burrito/TH.hs
@@ -1,0 +1,11 @@
+module Burrito.TH ( templateExpression, templatePattern ) where
+
+import qualified Burrito
+
+import Language.Haskell.TH.Syntax (Exp, Pat, Q, lift)
+
+templateExpression :: Burrito.Template -> Q Exp
+templateExpression = lift
+
+templatePattern :: Burrito.Template -> Q Pat
+templatePattern _ = fail "Template pattern: not yet implemented"

--- a/src/test/Main.hs
+++ b/src/test/Main.hs
@@ -17,6 +17,10 @@ import qualified GHC.Stack as Stack
 import qualified System.Exit as Exit
 import qualified Test.HUnit as Test
 
+#ifdef TemplateHaskell
+import qualified Burrito.QQ as QQ
+#endif
+
 main :: IO ()
 main = runTests $ do
 
@@ -1123,6 +1127,15 @@ main = runTests $ do
     test "{&%aa*}" ["%aa" =: "A"] "&%aa=A"
     test "{&%aa*}" ["%aa" =: ["A", "B"]] "&%aa=A&%aa=B"
     test "{&%aa*}" ["%aa" =: ["A" =: "1", "B" =: "2"]] "&A=1&B=2"
+
+#ifdef TemplateHaskell
+  label "qq" $
+      Writer.tell
+        . Test
+        $ "expression"
+        Test.~: Just [QQ.uriTemplate|http://example.com/search{?query}|]
+        Test.~?= Burrito.parse "http://example.com/search{?query}"
+#endif
 
 runTests :: Writer.WriterT Test IO a -> IO ()
 runTests writer = do


### PR DESCRIPTION
This PR adds a `uriTemplate` quasi-quoter to generate a `Template` value from a string at compile time. It is functioning, but mostly an idea/work-in-progress at this point.

I put this feature under a flag called `TemplateHaskell` so the package can still build without a `template-haskell` dependency. I assume I should also update the Travis config to test with/without the flag; I don't immediately know how to do that.

The potentially interesting part that I haven't written yet is the `quotePat` implementation, and I'd like your thoughts on whether it seems feasible. Would it be possible to write an inverse for `expand`?

```haskell
-- | forall tpl vars. extract tpl (expand vars tpl) = vars
extract ::
    Template
    -> String -- ^ URI
    -> [(String, Value)]
```

This would be neat because then maybe we could use that to make the quasi-quoter bind the variables from the template like... 

```haskell
case "http://example.com/search?q=haskell" of
    [uriTemplate|http://example.com/search{?query}|] -> Just query
    _ -> Nothing
```

