### PR TITLE
Add support for rendering templates

### DIFF
--- a/burrito.cabal
+++ b/burrito.cabal
@@ -47,6 +47,7 @@ library
   other-modules:
     Burrito.Expand
     Burrito.Parse
+    Burrito.Render
     Burrito.TH
     Burrito.Type.Character
     Burrito.Type.Expression

--- a/burrito.cabal
+++ b/burrito.cabal
@@ -36,15 +36,8 @@ library
     base >= 4.12.0 && < 4.15
     , template-haskell >= 2.14.0 && < 2.17
   default-language: Haskell98
-  exposed-modules: Burrito
-  ghc-options:
-    -Weverything
-    -Wno-all-missed-specialisations
-    -Wno-implicit-prelude
-    -Wno-missing-exported-signatures
-    -Wno-safe
-  hs-source-dirs: src/lib
-  other-modules:
+  exposed-modules:
+    Burrito
     Burrito.Expand
     Burrito.Parse
     Burrito.Render
@@ -60,6 +53,13 @@ library
     Burrito.Type.Token
     Burrito.Type.Value
     Burrito.Type.Variable
+  ghc-options:
+    -Weverything
+    -Wno-all-missed-specialisations
+    -Wno-implicit-prelude
+    -Wno-missing-exported-signatures
+    -Wno-safe
+  hs-source-dirs: src/lib
 
   if impl(ghc >= 8.8)
     ghc-options:

--- a/burrito.cabal
+++ b/burrito.cabal
@@ -52,6 +52,7 @@ library
     Burrito.Type.Template
     Burrito.Type.Token
     Burrito.Type.Value
+    Burrito.Type.VarChar
     Burrito.Type.Variable
   ghc-options:
     -Weverything

--- a/burrito.cabal
+++ b/burrito.cabal
@@ -75,6 +75,7 @@ test-suite test
     base -any
     , burrito -any
     , hspec >= 2.7.1 && < 2.8
+    , QuickCheck >= 2.13.2 && < 2.14
   default-language: Haskell98
   hs-source-dirs: src/test
   main-is: Main.hs

--- a/burrito.cabal
+++ b/burrito.cabal
@@ -42,8 +42,8 @@ library
     Burrito.Parse
     Burrito.Render
     Burrito.TH
-    Burrito.Type.Character
     Burrito.Type.Expression
+    Burrito.Type.LitChar
     Burrito.Type.Literal
     Burrito.Type.Modifier
     Burrito.Type.Name

--- a/burrito.cabal
+++ b/burrito.cabal
@@ -73,8 +73,7 @@ test-suite test
   build-depends:
     base -any
     , burrito -any
-    , HUnit >= 1.6.0 && < 1.7
-    , transformers >= 0.5.6 && < 0.6
+    , hspec >= 2.7.1 && < 2.8
   default-language: Haskell98
   hs-source-dirs: src/test
   main-is: Main.hs

--- a/src/lib/Burrito.hs
+++ b/src/lib/Burrito.hs
@@ -28,6 +28,7 @@
 -- In short, use @parse@ to parse templates and @expand@ to render them.
 module Burrito
   ( Parse.parse
+  , Render.render
   , Expand.expand
   , TH.uriTemplate
   , Template.Template
@@ -40,6 +41,7 @@ where
 
 import qualified Burrito.Expand as Expand
 import qualified Burrito.Parse as Parse
+import qualified Burrito.Render as Render
 import qualified Burrito.TH as TH
 import qualified Burrito.Type.Template as Template
 import qualified Burrito.Type.Value as Value

--- a/src/lib/Burrito/Expand.hs
+++ b/src/lib/Burrito/Expand.hs
@@ -1,3 +1,5 @@
+-- | Warning: This module is not considered part of Burrito's public API. As
+-- such, it may change at any time. Use it with caution!.
 module Burrito.Expand
   ( expand
   ) where

--- a/src/lib/Burrito/Expand.hs
+++ b/src/lib/Burrito/Expand.hs
@@ -4,8 +4,8 @@ module Burrito.Expand
   ( expand
   ) where
 
-import qualified Burrito.Type.Character as Character
 import qualified Burrito.Type.Expression as Expression
+import qualified Burrito.Type.LitChar as LitChar
 import qualified Burrito.Type.Literal as Literal
 import qualified Burrito.Type.Modifier as Modifier
 import qualified Burrito.Type.Name as Name
@@ -62,10 +62,10 @@ expandLiteral = concatMap expandCharacter . NonEmpty.toList . Literal.characters
 -- | Expands a single literal character for output. This is necessary to
 -- normalize percent encodings and to encode characters that aren't allowed to
 -- appear in URIs.
-expandCharacter :: Character.Character -> String
+expandCharacter :: LitChar.LitChar -> String
 expandCharacter character = case character of
-  Character.Encoded word8 -> percentEncodeWord8 word8
-  Character.Unencoded char -> escapeChar Operator.PlusSign char
+  LitChar.Encoded word8 -> percentEncodeWord8 word8
+  LitChar.Unencoded char -> escapeChar Operator.PlusSign char
 
 
 -- | If necessary, escapes a character for output with the given operator.

--- a/src/lib/Burrito/Parse.hs
+++ b/src/lib/Burrito/Parse.hs
@@ -171,7 +171,9 @@ parseCharacter = parseEither parseCharacterUnencoded parseCharacterEncoded
 
 -- | Parses an unencoded character in a literal.
 parseCharacterUnencoded :: Parser Character.Character
-parseCharacterUnencoded = Character.Unencoded <$> parseIf Character.isLiteral
+parseCharacterUnencoded = do
+  char <- parseIf Character.isLiteral
+  maybe Applicative.empty pure $ Character.makeUnencoded char
 
 
 -- | Parses a percent-encoded character in a literal.

--- a/src/lib/Burrito/Parse.hs
+++ b/src/lib/Burrito/Parse.hs
@@ -1,3 +1,5 @@
+-- | Warning: This module is not considered part of Burrito's public API. As
+-- such, it may change at any time. Use it with caution!.
 module Burrito.Parse
   ( parse
   ) where

--- a/src/lib/Burrito/Parse.hs
+++ b/src/lib/Burrito/Parse.hs
@@ -4,8 +4,8 @@ module Burrito.Parse
   ( parse
   ) where
 
-import qualified Burrito.Type.Character as Character
 import qualified Burrito.Type.Expression as Expression
+import qualified Burrito.Type.LitChar as LitChar
 import qualified Burrito.Type.Literal as Literal
 import qualified Burrito.Type.Modifier as Modifier
 import qualified Burrito.Type.Name as Name
@@ -165,22 +165,22 @@ parseLiteral = Literal.Literal <$> parseNonEmpty parseCharacter
 
 
 -- | Parses a character in a literal.
-parseCharacter :: Parser Character.Character
+parseCharacter :: Parser LitChar.LitChar
 parseCharacter = parseEither parseCharacterUnencoded parseCharacterEncoded
 
 
 -- | Parses an unencoded character in a literal.
-parseCharacterUnencoded :: Parser Character.Character
+parseCharacterUnencoded :: Parser LitChar.LitChar
 parseCharacterUnencoded = do
-  char <- parseIf Character.isLiteral
-  maybe Applicative.empty pure $ Character.makeUnencoded char
+  char <- parseIf LitChar.isLiteral
+  maybe Applicative.empty pure $ LitChar.makeUnencoded char
 
 
 -- | Parses a percent-encoded character in a literal.
-parseCharacterEncoded :: Parser Character.Character
+parseCharacterEncoded :: Parser LitChar.LitChar
 parseCharacterEncoded = do
   (hi, lo) <- parsePercentEncoded
-  pure . Character.Encoded $ intToWord8
+  pure . LitChar.Encoded $ intToWord8
     (Char.digitToInt hi * 16 + Char.digitToInt lo)
 
 

--- a/src/lib/Burrito/Parse.hs
+++ b/src/lib/Burrito/Parse.hs
@@ -356,18 +356,21 @@ parseMaxLength :: Parser Int
 parseMaxLength = do
   first <- parseNonZeroDigit
   rest <- parseUpTo 3 parseDigit
-  pure . fromDigits $ nonEmpty first rest
+  pure . fromDigits $ rest <> [first]
 
 
--- | Converts a list of digits into the number that they represent. For example
--- @[1, 2]@ becomes @12@.
-fromDigits :: NonEmpty.NonEmpty Int -> Int
-fromDigits = foldr1 ((+) . (10 *)) . NonEmpty.toList
+-- | Converts a backwards list of digits into the number that they represent.
+-- For example @[2, 1]@ becomes @12@.
+fromDigits :: [Int] -> Int
+fromDigits = foldr (\ digit -> (+ digit) . (* 10)) 0
 
 
 -- | Parses up to the given number of occurrences of the given parser. If the
 -- number is less than one, this will always succeed by returning the empty
 -- list.
+--
+-- Note that for performance reasons this returns the list in reverse order. If
+-- you need it in the order it was present in the input, use @reverse@.
 parseUpTo :: Int -> Parser a -> Parser [a]
 parseUpTo = parseUpToWith []
 

--- a/src/lib/Burrito/Parse.hs
+++ b/src/lib/Burrito/Parse.hs
@@ -219,7 +219,7 @@ parseVarcharFirst = parseEither parseVarcharUnencoded parseVarcharEncoded
 
 -- | Parses an unencoded character in a variable name.
 parseVarcharUnencoded :: Parser (NonEmpty.NonEmpty Char)
-parseVarcharUnencoded = NonEmpty.singleton <$> parseIf isVarchar
+parseVarcharUnencoded = NonEmpty.singleton <$> parseIf Name.isVarchar
 
 
 -- | Parses a percent-encoded character in a variable name.
@@ -235,15 +235,6 @@ parseVarcharRest :: Parser (NonEmpty.NonEmpty Char)
 parseVarcharRest = parseEither
   (nonEmpty <$> parseChar '.' <*> fmap NonEmpty.toList parseVarcharFirst)
   parseVarcharFirst
-
-
--- | Returns true if the given character is in the @varchar@ range defined by
--- section 2.3 of the RFC. Note that this does not include the @pct-encoded@
--- part of the grammar because that requires multiple characters to match.
-isVarchar :: Char -> Bool
-isVarchar x = case x of
-  '_' -> True
-  _ -> isAlpha x || Char.isDigit x
 
 
 -- | Adds a bunch of non-empty lists to the end of one non-empty list, while
@@ -404,12 +395,6 @@ isNonZeroDigit x = case x of
 -- | Parses a single decimal digit and returns that digit's value.
 parseDigit :: Parser Int
 parseDigit = Char.digitToInt <$> parseIf Char.isDigit
-
-
--- | Returns true if the given character is in the @ALPHA@ range defined by
--- section 1.5 of the RFC.
-isAlpha :: Char -> Bool
-isAlpha x = Char.isAsciiUpper x || Char.isAsciiLower x
 
 
 -- | Parses an @explode@ as defined by section 2.4.2 of the RFC.

--- a/src/lib/Burrito/Parse.hs
+++ b/src/lib/Burrito/Parse.hs
@@ -2,7 +2,8 @@
 -- such, it may change at any time. Use it with caution!.
 module Burrito.Parse
   ( parse
-  ) where
+  )
+where
 
 import qualified Burrito.Type.Expression as Expression
 import qualified Burrito.Type.LitChar as LitChar
@@ -204,7 +205,10 @@ parseVarspec :: Parser Variable.Variable
 parseVarspec = do
   name <- parseVarname
   modifier <- parseModifier
-  pure $ Variable.Variable { Variable.name = name, Variable.modifier = modifier }
+  pure $ Variable.Variable
+    { Variable.name = name
+    , Variable.modifier = modifier
+    }
 
 
 -- | Parses a @varname@ as defined by section 2.3 of the RFC.
@@ -237,9 +241,10 @@ parseVarcharEncoded = do
 -- | Parses a non-first character in a variable name. This is like
 -- 'parseVarcharFirst' except it allows periods.
 parseVarcharRest :: Parser (Bool, VarChar.VarChar)
-parseVarcharRest = (,)
-  <$> parseEither (True <$ parseChar_ '.') (pure False)
-  <*> parseVarcharFirst
+parseVarcharRest =
+  (,)
+    <$> parseEither (True <$ parseChar_ '.') (pure False)
+    <*> parseVarcharFirst
 
 
 -- | Constructs a non-empty list without using an operator.
@@ -350,7 +355,7 @@ parseMaxLength = do
 -- | Converts a backwards list of digits into the number that they represent.
 -- For example @[2, 1]@ becomes @12@.
 fromDigits :: [Int] -> Int
-fromDigits = foldr (\ digit -> (+ digit) . (* 10)) 0
+fromDigits = foldr (\digit -> (+ digit) . (* 10)) 0
 
 
 -- | Parses up to the given number of occurrences of the given parser. If the

--- a/src/lib/Burrito/Render.hs
+++ b/src/lib/Burrito/Render.hs
@@ -74,7 +74,11 @@ renderVariable variable = mconcat
 renderName :: Name.Name -> String
 renderName name = mconcat
   [ renderVarChar $ Name.first name
-  , concatMap (\ (x, y) -> (if x then "." else "") <> renderVarChar y) $ Name.rest name
+  , concatMap
+      (\(fullStop, varChar) ->
+        (if fullStop then "." else "") <> renderVarChar varChar
+      )
+    $ Name.rest name
   ]
 
 
@@ -95,7 +99,8 @@ renderModifier modifier = case modifier of
 
 -- | Renders a literal token.
 renderLiteral :: Literal.Literal -> String
-renderLiteral = concatMap renderCharacter . NonEmpty.toList . Literal.characters
+renderLiteral =
+  concatMap renderCharacter . NonEmpty.toList . Literal.characters
 
 
 -- | Renders a character in a literal token.

--- a/src/lib/Burrito/Render.hs
+++ b/src/lib/Burrito/Render.hs
@@ -14,6 +14,7 @@ import qualified Burrito.Type.NonEmpty as NonEmpty
 import qualified Burrito.Type.Operator as Operator
 import qualified Burrito.Type.Template as Template
 import qualified Burrito.Type.Token as Token
+import qualified Burrito.Type.VarChar as VarChar
 import qualified Burrito.Type.Variable as Variable
 import qualified Data.List as List
 import qualified Data.Word as Word
@@ -71,7 +72,17 @@ renderVariable variable = mconcat
 
 -- | Renders a variable name.
 renderName :: Name.Name -> String
-renderName = NonEmpty.toList . Name.chars
+renderName name = mconcat
+  [ renderVarChar $ Name.first name
+  , concatMap (\ (x, y) -> (if x then "." else "") <> renderVarChar y) $ Name.rest name
+  ]
+
+
+-- | Renders one logical character of a variable name.
+renderVarChar :: VarChar.VarChar -> String
+renderVarChar varChar = case varChar of
+  VarChar.Encoded hi lo -> ['%', hi, lo]
+  VarChar.Unencoded char -> [char]
 
 
 -- | Renders a variable modifier.

--- a/src/lib/Burrito/Render.hs
+++ b/src/lib/Burrito/Render.hs
@@ -1,0 +1,103 @@
+module Burrito.Render
+  ( render
+  )
+where
+
+import qualified Burrito.Type.Character as Character
+import qualified Burrito.Type.Expression as Expression
+import qualified Burrito.Type.Literal as Literal
+import qualified Burrito.Type.Modifier as Modifier
+import qualified Burrito.Type.Name as Name
+import qualified Burrito.Type.NonEmpty as NonEmpty
+import qualified Burrito.Type.Operator as Operator
+import qualified Burrito.Type.Template as Template
+import qualified Burrito.Type.Token as Token
+import qualified Burrito.Type.Variable as Variable
+import qualified Data.List as List
+import qualified Data.Word as Word
+import qualified Text.Printf as Printf
+
+
+-- | Renders a template back into a string. This is essentially the opposite of
+-- @parse@.
+render :: Template.Template -> String
+render = concatMap renderToken . Template.tokens
+
+
+-- | Renders a token in a template.
+renderToken :: Token.Token -> String
+renderToken token = case token of
+  Token.Expression expression -> renderExpression expression
+  Token.Literal literal -> renderLiteral literal
+
+
+-- | Renders an expression token.
+renderExpression :: Expression.Expression -> String
+renderExpression expression = mconcat
+  [ "{"
+  , renderOperator $ Expression.operator expression
+  , renderVariables $ Expression.variables expression
+  , "}"
+  ]
+
+
+-- | Renders an operator in an expression.
+renderOperator :: Operator.Operator -> String
+renderOperator operator = case operator of
+  Operator.Ampersand -> "&"
+  Operator.FullStop -> "."
+  Operator.None -> ""
+  Operator.NumberSign -> "#"
+  Operator.PlusSign -> "+"
+  Operator.QuestionMark -> "?"
+  Operator.Semicolon -> ";"
+  Operator.Solidus -> "/"
+
+
+-- | Renders a bunch of variables in an expression.
+renderVariables :: NonEmpty.NonEmpty Variable.Variable -> String
+renderVariables = List.intercalate "," . fmap renderVariable . NonEmpty.toList
+
+
+-- | Renders a variable in an expression.
+renderVariable :: Variable.Variable -> String
+renderVariable variable = mconcat
+  [ renderName $ Variable.name variable
+  , renderModifier $ Variable.modifier variable
+  ]
+
+
+-- | Renders a variable name.
+renderName :: Name.Name -> String
+renderName = NonEmpty.toList . Name.chars
+
+
+-- | Renders a variable modifier.
+renderModifier :: Modifier.Modifier -> String
+renderModifier modifier = case modifier of
+  Modifier.Asterisk -> "*"
+  Modifier.Colon int -> Printf.printf ":%d" int
+  Modifier.None -> ""
+
+
+-- | Renders a literal token.
+renderLiteral :: Literal.Literal -> String
+renderLiteral = concatMap renderCharacter . NonEmpty.toList . Literal.characters
+
+
+-- | Renders a character in a literal token.
+renderCharacter :: Character.Character -> String
+renderCharacter character = case character of
+  Character.Encoded word8 -> renderEncodedCharacter word8
+  Character.Unencoded char -> renderUnencodedCharacter char
+
+
+-- | Renders an encoded character by percent encoding it with uppercase
+-- hexadecimal digits.
+renderEncodedCharacter :: Word.Word8 -> String
+renderEncodedCharacter = Printf.printf "%%%02X"
+
+
+-- | Renders an unencoded character by simply turning it into a string.
+renderUnencodedCharacter :: Char -> String
+renderUnencodedCharacter = pure

--- a/src/lib/Burrito/Render.hs
+++ b/src/lib/Burrito/Render.hs
@@ -5,8 +5,8 @@ module Burrito.Render
   )
 where
 
-import qualified Burrito.Type.Character as Character
 import qualified Burrito.Type.Expression as Expression
+import qualified Burrito.Type.LitChar as LitChar
 import qualified Burrito.Type.Literal as Literal
 import qualified Burrito.Type.Modifier as Modifier
 import qualified Burrito.Type.Name as Name
@@ -88,10 +88,10 @@ renderLiteral = concatMap renderCharacter . NonEmpty.toList . Literal.characters
 
 
 -- | Renders a character in a literal token.
-renderCharacter :: Character.Character -> String
+renderCharacter :: LitChar.LitChar -> String
 renderCharacter character = case character of
-  Character.Encoded word8 -> renderEncodedCharacter word8
-  Character.Unencoded char -> renderUnencodedCharacter char
+  LitChar.Encoded word8 -> renderEncodedCharacter word8
+  LitChar.Unencoded char -> renderUnencodedCharacter char
 
 
 -- | Renders an encoded character by percent encoding it with uppercase

--- a/src/lib/Burrito/Render.hs
+++ b/src/lib/Burrito/Render.hs
@@ -1,3 +1,5 @@
+-- | Warning: This module is not considered part of Burrito's public API. As
+-- such, it may change at any time. Use it with caution!.
 module Burrito.Render
   ( render
   )

--- a/src/lib/Burrito/TH.hs
+++ b/src/lib/Burrito/TH.hs
@@ -2,7 +2,8 @@
 -- such, it may change at any time. Use it with caution!.
 module Burrito.TH
   ( uriTemplate
-  ) where
+  )
+where
 
 import qualified Burrito.Parse as Parse
 import qualified Language.Haskell.TH.Quote as TH

--- a/src/lib/Burrito/TH.hs
+++ b/src/lib/Burrito/TH.hs
@@ -1,3 +1,5 @@
+-- | Warning: This module is not considered part of Burrito's public API. As
+-- such, it may change at any time. Use it with caution!.
 module Burrito.TH
   ( uriTemplate
   ) where

--- a/src/lib/Burrito/Type/Character.hs
+++ b/src/lib/Burrito/Type/Character.hs
@@ -4,6 +4,7 @@
 -- such, it may change at any time. Use it with caution!
 module Burrito.Type.Character
   ( Character(..)
+  , isLiteral
   ) where
 
 import qualified Data.Word as Word
@@ -15,5 +16,69 @@ import qualified Language.Haskell.TH.Syntax as TH
 -- printable characters. In other words @A@ is more likely than @%41@.
 data Character
   = Encoded Word.Word8
+  -- ^ This deliberately is not case sensitive. The tokens @%aa@ and @%AA@ are
+  -- both represented as @Encoded 0xAA@.
   | Unencoded Char
+  -- ^ This assumes that the character passes the @isLiteral@ predicate.
   deriving (Eq, TH.Lift, Show)
+
+
+-- | Returns true if the given character is in the @literal@ range defined by
+-- section 2.1 of the RFC.
+isLiteral :: Char -> Bool
+isLiteral x = case x of
+  ' ' -> False
+  '"' -> False
+  '\'' -> False
+  '%' -> False
+  '<' -> False
+  '>' -> False
+  '\\' -> False
+  '^' -> False
+  '`' -> False
+  '{' -> False
+  '|' -> False
+  '}' -> False
+  _ -> between '\x20' '\x7e' x || isUcschar x || isIprivate x
+
+
+-- | Returns true if the given character is in the @ucschar@ range defined by
+-- section 1.5 of the RFC.
+isUcschar :: Char -> Bool
+isUcschar x =
+  between '\xa0' '\xd7ff' x
+    || between '\xf900' '\xfdcf' x
+    || between '\xfdf0' '\xffef' x
+    || between '\x10000' '\x1fffd' x
+    || between '\x20000' '\x2fffd' x
+    || between '\x30000' '\x3fffd' x
+    || between '\x40000' '\x4fffd' x
+    || between '\x50000' '\x5fffd' x
+    || between '\x60000' '\x6fffd' x
+    || between '\x70000' '\x7fffd' x
+    || between '\x80000' '\x8fffd' x
+    || between '\x90000' '\x9fffd' x
+    || between '\xa0000' '\xafffd' x
+    || between '\xb0000' '\xbfffd' x
+    || between '\xc0000' '\xcfffd' x
+    || between '\xd0000' '\xdfffd' x
+    || between '\xe1000' '\xefffd' x
+
+
+-- | Returns true if the given character is in the @iprivate@ range defined by
+-- section 1.5 of the RFC.
+isIprivate :: Char -> Bool
+isIprivate x =
+  between '\xe000' '\xf8ff' x
+    || between '\xf0000' '\xffffd' x
+    || between '\x100000' '\x10fffd' x
+
+
+-- | Returns true if the value is between the given inclusive bounds.
+between
+  :: Ord a
+  => a -- ^ lower bound
+  -> a -- ^ upper bound
+  -> a
+  -> Bool
+between lo hi x = lo <= x && x <= hi

--- a/src/lib/Burrito/Type/Character.hs
+++ b/src/lib/Burrito/Type/Character.hs
@@ -5,6 +5,7 @@
 module Burrito.Type.Character
   ( Character(..)
   , isLiteral
+  , makeUnencoded
   ) where
 
 import qualified Data.Word as Word
@@ -19,8 +20,15 @@ data Character
   -- ^ This deliberately is not case sensitive. The tokens @%aa@ and @%AA@ are
   -- both represented as @Encoded 0xAA@.
   | Unencoded Char
-  -- ^ This assumes that the character passes the @isLiteral@ predicate.
+  -- ^ This assumes that the character passes the @isLiteral@ predicate. You
+  -- should prefer using @makeUnencoded@ to create these values.
   deriving (Eq, TH.Lift, Show)
+
+
+-- | If the character passes @isLiteral@, returns an @Unencoded@ character.
+-- Otherwise returns nothing.
+makeUnencoded :: Char -> Maybe Character
+makeUnencoded char = if isLiteral char then Just $ Unencoded char else Nothing
 
 
 -- | Returns true if the given character is in the @literal@ range defined by

--- a/src/lib/Burrito/Type/Character.hs
+++ b/src/lib/Burrito/Type/Character.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE DeriveLift #-}
 
+-- | Warning: This module is not considered part of Burrito's public API. As
+-- such, it may change at any time. Use it with caution!
 module Burrito.Type.Character
   ( Character(..)
   ) where

--- a/src/lib/Burrito/Type/Expression.hs
+++ b/src/lib/Burrito/Type/Expression.hs
@@ -4,7 +4,8 @@
 -- such, it may change at any time. Use it with caution!.
 module Burrito.Type.Expression
   ( Expression(..)
-  ) where
+  )
+where
 
 import qualified Burrito.Type.NonEmpty as NonEmpty
 import qualified Burrito.Type.Operator as Operator

--- a/src/lib/Burrito/Type/Expression.hs
+++ b/src/lib/Burrito/Type/Expression.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE DeriveLift #-}
 
+-- | Warning: This module is not considered part of Burrito's public API. As
+-- such, it may change at any time. Use it with caution!.
 module Burrito.Type.Expression
   ( Expression(..)
   ) where

--- a/src/lib/Burrito/Type/LitChar.hs
+++ b/src/lib/Burrito/Type/LitChar.hs
@@ -6,7 +6,8 @@ module Burrito.Type.LitChar
   ( LitChar(..)
   , isLiteral
   , makeUnencoded
-  ) where
+  )
+where
 
 import qualified Data.Word as Word
 import qualified Language.Haskell.TH.Syntax as TH

--- a/src/lib/Burrito/Type/LitChar.hs
+++ b/src/lib/Burrito/Type/LitChar.hs
@@ -2,8 +2,8 @@
 
 -- | Warning: This module is not considered part of Burrito's public API. As
 -- such, it may change at any time. Use it with caution!
-module Burrito.Type.Character
-  ( Character(..)
+module Burrito.Type.LitChar
+  ( LitChar(..)
   , isLiteral
   , makeUnencoded
   ) where
@@ -15,7 +15,7 @@ import qualified Language.Haskell.TH.Syntax as TH
 -- | Represents a character in a literal. Although encoded characters are
 -- allowed to have any value, typically they will not include most ASCII
 -- printable characters. In other words @A@ is more likely than @%41@.
-data Character
+data LitChar
   = Encoded Word.Word8
   -- ^ This deliberately is not case sensitive. The tokens @%aa@ and @%AA@ are
   -- both represented as @Encoded 0xAA@.
@@ -27,7 +27,7 @@ data Character
 
 -- | If the character passes @isLiteral@, returns an @Unencoded@ character.
 -- Otherwise returns nothing.
-makeUnencoded :: Char -> Maybe Character
+makeUnencoded :: Char -> Maybe LitChar
 makeUnencoded char = if isLiteral char then Just $ Unencoded char else Nothing
 
 

--- a/src/lib/Burrito/Type/Literal.hs
+++ b/src/lib/Burrito/Type/Literal.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE DeriveLift #-}
 
+-- | Warning: This module is not considered part of Burrito's public API. As
+-- such, it may change at any time. Use it with caution!.
 module Burrito.Type.Literal
   ( Literal(..)
   ) where

--- a/src/lib/Burrito/Type/Literal.hs
+++ b/src/lib/Burrito/Type/Literal.hs
@@ -4,7 +4,8 @@
 -- such, it may change at any time. Use it with caution!.
 module Burrito.Type.Literal
   ( Literal(..)
-  ) where
+  )
+where
 
 import qualified Burrito.Type.LitChar as LitChar
 import qualified Burrito.Type.NonEmpty as NonEmpty

--- a/src/lib/Burrito/Type/Literal.hs
+++ b/src/lib/Burrito/Type/Literal.hs
@@ -6,12 +6,12 @@ module Burrito.Type.Literal
   ( Literal(..)
   ) where
 
-import qualified Burrito.Type.Character as Character
+import qualified Burrito.Type.LitChar as LitChar
 import qualified Burrito.Type.NonEmpty as NonEmpty
 import qualified Language.Haskell.TH.Syntax as TH
 
 
 -- | Represents a literal in a token.
 newtype Literal = Literal
-  { characters :: NonEmpty.NonEmpty Character.Character
+  { characters :: NonEmpty.NonEmpty LitChar.LitChar
   } deriving (Eq, TH.Lift, Show)

--- a/src/lib/Burrito/Type/Modifier.hs
+++ b/src/lib/Burrito/Type/Modifier.hs
@@ -4,15 +4,30 @@
 -- such, it may change at any time. Use it with caution!.
 module Burrito.Type.Modifier
   ( Modifier(..)
+  , makeColon
   ) where
 
 import qualified Language.Haskell.TH.Syntax as TH
 
 
--- | Represents a modifier on a variable. The number associated with a prefix
--- modifier will be between 1 and 9999 inclusive.
+-- | Represents a modifier on a variable.
 data Modifier
   = Asterisk
   | Colon Int
+  -- ^ This assumes that the number passes the @isValidMaxLength@ predicate.
+  -- You should prefer using @makeColon@ to create these values.
   | None
   deriving (Eq, TH.Lift, Show)
+
+
+-- | If the number passes @isValidMaxLength@, returns a @Colon@ modifier.
+-- Otherwise returns nothing.
+makeColon :: Int -> Maybe Modifier
+makeColon maxLength =
+  if isValidMaxLength maxLength then Just $ Colon maxLength else Nothing
+
+
+-- | Returns true if the given number is a valid @max-length@ as defined by
+-- section 2.4.1 of the RFC.
+isValidMaxLength :: Int -> Bool
+isValidMaxLength maxLength = 1 <= maxLength && maxLength <= 9999

--- a/src/lib/Burrito/Type/Modifier.hs
+++ b/src/lib/Burrito/Type/Modifier.hs
@@ -5,7 +5,8 @@
 module Burrito.Type.Modifier
   ( Modifier(..)
   , makeColon
-  ) where
+  )
+where
 
 import qualified Language.Haskell.TH.Syntax as TH
 

--- a/src/lib/Burrito/Type/Modifier.hs
+++ b/src/lib/Burrito/Type/Modifier.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE DeriveLift #-}
 
+-- | Warning: This module is not considered part of Burrito's public API. As
+-- such, it may change at any time. Use it with caution!.
 module Burrito.Type.Modifier
   ( Modifier(..)
   ) where

--- a/src/lib/Burrito/Type/Name.hs
+++ b/src/lib/Burrito/Type/Name.hs
@@ -4,11 +4,9 @@
 -- such, it may change at any time. Use it with caution!.
 module Burrito.Type.Name
   ( Name(..)
-  , isVarchar
   ) where
 
-import qualified Burrito.Type.NonEmpty as NonEmpty
-import qualified Data.Char as Char
+import qualified Burrito.Type.VarChar as VarChar
 import qualified Language.Haskell.TH.Syntax as TH
 
 
@@ -16,21 +14,12 @@ import qualified Language.Haskell.TH.Syntax as TH
 -- names allow ASCII letters and numbers, underscores, percent encoded triples,
 -- and periods. However the periods cannot appear at the beginning or end, and
 -- there can't be more than one of them in a row.
-newtype Name = Name
-  { chars :: NonEmpty.NonEmpty Char
+data Name = Name
+  { first :: VarChar.VarChar
+  -- ^ The first character is any valid @varchar@, including underscores and
+  -- percent encoded triples.
+  , rest :: [(Bool, VarChar.VarChar)]
+  -- ^ Every other character has the same constraints, but they may also be
+  -- preceeded by a full stop (period). That's what the @Bool@ represents:
+  -- @True@ means there is a period.
   } deriving (Eq, TH.Lift, Show)
-
-
--- | Returns true if the given character is in the @varchar@ range defined by
--- section 2.3 of the RFC. Note that this does not include the @pct-encoded@
--- part of the grammar because that requires multiple characters to match.
-isVarchar :: Char -> Bool
-isVarchar x = case x of
-  '_' -> True
-  _ -> isAlpha x || Char.isDigit x
-
-
--- | Returns true if the given character is in the @ALPHA@ range defined by
--- section 1.5 of the RFC.
-isAlpha :: Char -> Bool
-isAlpha x = Char.isAsciiUpper x || Char.isAsciiLower x

--- a/src/lib/Burrito/Type/Name.hs
+++ b/src/lib/Burrito/Type/Name.hs
@@ -4,9 +4,11 @@
 -- such, it may change at any time. Use it with caution!.
 module Burrito.Type.Name
   ( Name(..)
+  , isVarchar
   ) where
 
 import qualified Burrito.Type.NonEmpty as NonEmpty
+import qualified Data.Char as Char
 import qualified Language.Haskell.TH.Syntax as TH
 
 
@@ -17,3 +19,18 @@ import qualified Language.Haskell.TH.Syntax as TH
 newtype Name = Name
   { chars :: NonEmpty.NonEmpty Char
   } deriving (Eq, TH.Lift, Show)
+
+
+-- | Returns true if the given character is in the @varchar@ range defined by
+-- section 2.3 of the RFC. Note that this does not include the @pct-encoded@
+-- part of the grammar because that requires multiple characters to match.
+isVarchar :: Char -> Bool
+isVarchar x = case x of
+  '_' -> True
+  _ -> isAlpha x || Char.isDigit x
+
+
+-- | Returns true if the given character is in the @ALPHA@ range defined by
+-- section 1.5 of the RFC.
+isAlpha :: Char -> Bool
+isAlpha x = Char.isAsciiUpper x || Char.isAsciiLower x

--- a/src/lib/Burrito/Type/Name.hs
+++ b/src/lib/Burrito/Type/Name.hs
@@ -4,7 +4,8 @@
 -- such, it may change at any time. Use it with caution!.
 module Burrito.Type.Name
   ( Name(..)
-  ) where
+  )
+where
 
 import qualified Burrito.Type.VarChar as VarChar
 import qualified Language.Haskell.TH.Syntax as TH

--- a/src/lib/Burrito/Type/Name.hs
+++ b/src/lib/Burrito/Type/Name.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE DeriveLift #-}
 
+-- | Warning: This module is not considered part of Burrito's public API. As
+-- such, it may change at any time. Use it with caution!.
 module Burrito.Type.Name
   ( Name(..)
   ) where

--- a/src/lib/Burrito/Type/NonEmpty.hs
+++ b/src/lib/Burrito/Type/NonEmpty.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE DeriveLift #-}
 
+-- | Warning: This module is not considered part of Burrito's public API. As
+-- such, it may change at any time. Use it with caution!.
 module Burrito.Type.NonEmpty
   ( NonEmpty(..)
   , fromList

--- a/src/lib/Burrito/Type/NonEmpty.hs
+++ b/src/lib/Burrito/Type/NonEmpty.hs
@@ -7,7 +7,8 @@ module Burrito.Type.NonEmpty
   , fromList
   , singleton
   , toList
-  ) where
+  )
+where
 
 import qualified Language.Haskell.TH.Syntax as TH
 

--- a/src/lib/Burrito/Type/Operator.hs
+++ b/src/lib/Burrito/Type/Operator.hs
@@ -4,7 +4,8 @@
 -- such, it may change at any time. Use it with caution!.
 module Burrito.Type.Operator
   ( Operator(..)
-  ) where
+  )
+where
 
 import qualified Language.Haskell.TH.Syntax as TH
 

--- a/src/lib/Burrito/Type/Operator.hs
+++ b/src/lib/Burrito/Type/Operator.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE DeriveLift #-}
 
+-- | Warning: This module is not considered part of Burrito's public API. As
+-- such, it may change at any time. Use it with caution!.
 module Burrito.Type.Operator
   ( Operator(..)
   ) where

--- a/src/lib/Burrito/Type/Template.hs
+++ b/src/lib/Burrito/Type/Template.hs
@@ -4,7 +4,8 @@
 -- such, it may change at any time. Use it with caution!.
 module Burrito.Type.Template
   ( Template(..)
-  ) where
+  )
+where
 
 import qualified Burrito.Type.Token as Token
 import qualified Language.Haskell.TH.Syntax as TH

--- a/src/lib/Burrito/Type/Template.hs
+++ b/src/lib/Burrito/Type/Template.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE DeriveLift #-}
 
+-- | Warning: This module is not considered part of Burrito's public API. As
+-- such, it may change at any time. Use it with caution!.
 module Burrito.Type.Template
   ( Template(..)
   ) where

--- a/src/lib/Burrito/Type/Token.hs
+++ b/src/lib/Burrito/Type/Token.hs
@@ -4,7 +4,8 @@
 -- such, it may change at any time. Use it with caution!.
 module Burrito.Type.Token
   ( Token(..)
-  ) where
+  )
+where
 
 import qualified Burrito.Type.Expression as Expression
 import qualified Burrito.Type.Literal as Literal

--- a/src/lib/Burrito/Type/Token.hs
+++ b/src/lib/Burrito/Type/Token.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE DeriveLift #-}
 
+-- | Warning: This module is not considered part of Burrito's public API. As
+-- such, it may change at any time. Use it with caution!.
 module Burrito.Type.Token
   ( Token(..)
   ) where

--- a/src/lib/Burrito/Type/Value.hs
+++ b/src/lib/Burrito/Type/Value.hs
@@ -1,3 +1,5 @@
+-- | Warning: This module is not considered part of Burrito's public API. As
+-- such, it may change at any time. Use it with caution!.
 module Burrito.Type.Value
   ( Value(..)
   ) where

--- a/src/lib/Burrito/Type/Value.hs
+++ b/src/lib/Burrito/Type/Value.hs
@@ -2,7 +2,8 @@
 -- such, it may change at any time. Use it with caution!.
 module Burrito.Type.Value
   ( Value(..)
-  ) where
+  )
+where
 
 
 -- | Represents a value that can be substituted into a template. Can be a

--- a/src/lib/Burrito/Type/VarChar.hs
+++ b/src/lib/Burrito/Type/VarChar.hs
@@ -32,8 +32,7 @@ data VarChar
 -- | Makes sure that both characters are valid hexadecimal digits. If they are,
 -- returns an @Encoded@ character. Otherwise returns nothing.
 makeEncoded :: Char -> Char -> Maybe VarChar
-makeEncoded hi lo =
-  if Char.isHexDigit hi && Char.isHexDigit lo
+makeEncoded hi lo = if Char.isHexDigit hi && Char.isHexDigit lo
   then Just $ Encoded hi lo
   else Nothing
 

--- a/src/lib/Burrito/Type/VarChar.hs
+++ b/src/lib/Burrito/Type/VarChar.hs
@@ -1,0 +1,59 @@
+{-# LANGUAGE DeriveLift #-}
+
+-- | Warning: This module is not considered part of Burrito's public API. As
+-- such, it may change at any time. Use it with caution!.
+module Burrito.Type.VarChar
+  ( VarChar(..)
+  , makeEncoded
+  , makeUnencoded
+  , isVarchar
+  )
+where
+
+import qualified Data.Char as Char
+import qualified Language.Haskell.TH.Syntax as TH
+
+
+-- | Represents a single logical character in a variable name.
+data VarChar
+  = Encoded Char Char
+  -- ^ A percent encoded triple. Note that this represents three literal
+  -- characters in the input, even though logically we always treat it as one
+  -- character. The two arguments are the high and the low hexadecimal digits,
+  -- respectively. This representation intentially keeps track of their case,
+  -- so as to avoid confusing values like @%aa@ and @%AA@. You should use
+  -- @makeEncoded@ to build these values.
+  | Unencoded Char
+  -- ^ A literal unencoded character. You should use @makeUnencoded@ to build
+  -- these values.
+  deriving (Eq, TH.Lift, Show)
+
+
+-- | Makes sure that both characters are valid hexadecimal digits. If they are,
+-- returns an @Encoded@ character. Otherwise returns nothing.
+makeEncoded :: Char -> Char -> Maybe VarChar
+makeEncoded hi lo =
+  if Char.isHexDigit hi && Char.isHexDigit lo
+  then Just $ Encoded hi lo
+  else Nothing
+
+
+-- | Makes sure that the character passes the @isVarchar@ predicate. If it
+-- does, returns an @Unencoded@ character. Otherwise returns nothing.
+makeUnencoded :: Char -> Maybe VarChar
+makeUnencoded char = if isVarchar char then Just $ Unencoded char else Nothing
+
+
+-- | Returns true if the given character is in the @varchar@ range defined by
+-- section 2.3 of the RFC. Note that this does not include the @pct-encoded@
+-- part of the grammar because that requires multiple characters to match.
+isVarchar :: Char -> Bool
+isVarchar x = case x of
+  '_' -> True
+  _ -> isAlpha x || Char.isDigit x
+
+
+-- | Returns true if the given character is in the @ALPHA@ range defined by
+-- section 1.5 of the RFC.
+isAlpha :: Char -> Bool
+isAlpha x = Char.isAsciiUpper x || Char.isAsciiLower x

--- a/src/lib/Burrito/Type/Variable.hs
+++ b/src/lib/Burrito/Type/Variable.hs
@@ -4,7 +4,8 @@
 -- such, it may change at any time. Use it with caution!.
 module Burrito.Type.Variable
   ( Variable(..)
-  ) where
+  )
+where
 
 import qualified Burrito.Type.Modifier as Modifier
 import qualified Burrito.Type.Name as Name

--- a/src/lib/Burrito/Type/Variable.hs
+++ b/src/lib/Burrito/Type/Variable.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE DeriveLift #-}
 
+-- | Warning: This module is not considered part of Burrito's public API. As
+-- such, it may change at any time. Use it with caution!.
 module Burrito.Type.Variable
   ( Variable(..)
   ) where

--- a/src/test/Main.hs
+++ b/src/test/Main.hs
@@ -25,6 +25,7 @@ import qualified Data.Either as Either
 import qualified Data.Maybe as Maybe
 import qualified Data.String as String
 import qualified GHC.Exts as Exts
+import qualified GHC.Stack as Stack
 import qualified Test.Hspec as Test
 import qualified Test.QuickCheck as QC
 
@@ -1159,7 +1160,8 @@ main = Test.hspec . Test.describe "Burrito" $ do
       qq [Burrito.uriTemplate|{&a}|] "{&a}"
 
 test
-  :: String
+  :: Stack.HasCallStack
+  => String
   -> Values
   -> Expected
   -> IO ()

--- a/src/test/Main.hs
+++ b/src/test/Main.hs
@@ -1319,8 +1319,10 @@ instance QC.Arbitrary Literal.Literal where
 instance QC.Arbitrary Character.Character where
   arbitrary = QC.oneof
     [ Character.Encoded <$> QC.arbitrary
-    , Character.Unencoded <$> QC.suchThat QC.arbitrary Character.isLiteral
+    , do
+      char <- QC.suchThat QC.arbitrary Character.isLiteral
+      maybe QC.discard pure $ Character.makeUnencoded char
     ]
   shrink character = case character of
     Character.Encoded word8 -> Character.Encoded <$> QC.shrink word8
-    Character.Unencoded char -> fmap Character.Unencoded . filter Character.isLiteral $ QC.shrink char
+    Character.Unencoded char -> Maybe.mapMaybe Character.makeUnencoded $ QC.shrink char

--- a/src/test/Main.hs
+++ b/src/test/Main.hs
@@ -22,6 +22,7 @@ import qualified Burrito.Type.Template as Template
 import qualified Burrito.Type.Token as Token
 import qualified Burrito.Type.Variable as Variable
 import qualified Data.Either as Either
+import qualified Data.Maybe as Maybe
 import qualified Data.String as String
 import qualified GHC.Exts as Exts
 import qualified Test.Hspec as Test
@@ -1288,12 +1289,14 @@ instance QC.Arbitrary Variable.Variable where
 instance QC.Arbitrary Modifier.Modifier where
   arbitrary = QC.oneof
     [ pure Modifier.Asterisk
-    , Modifier.Colon <$> QC.choose (1, 9999)
+    , do
+      maxLength <- QC.choose (1, 9999)
+      maybe QC.discard pure $ Modifier.makeColon maxLength
     , pure Modifier.None
     ]
   shrink modifier = case modifier of
     Modifier.Asterisk -> [Modifier.None]
-    Modifier.Colon int -> fmap Modifier.Colon . filter (\ x -> 1 <= x && x <= 9999) $ QC.shrink int
+    Modifier.Colon int -> Maybe.mapMaybe Modifier.makeColon $ QC.shrink int
     Modifier.None -> []
 
 instance QC.Arbitrary Name.Name where

--- a/src/test/Main.hs
+++ b/src/test/Main.hs
@@ -1306,17 +1306,9 @@ instance QC.Arbitrary Name.Name where
 genNonEmpty :: QC.Gen a -> QC.Gen (NonEmpty.NonEmpty a)
 genNonEmpty gen = NonEmpty.NonEmpty <$> gen <*> QC.listOf gen
 
--- TODO: percent escapes, periods
--- TODO: deduplicate with `isVarchar`
+-- TODO: percent escapes, periods: "a", "b.c", "%de", "%01.f", "g.%02", "%03.%04", "a.b.c", "a.bc.d"
 arbitraryNameChar :: QC.Gen Char
-arbitraryNameChar = QC.suchThat QC.arbitrary isNameChar
-
-isNameChar :: Char -> Bool
-isNameChar x = case x of
-  '_' -> True
-  _ -> '0' <= x && x <= '9'
-    || 'A' <= x && x <= 'Z'
-    || 'a' <= x && x <= 'z'
+arbitraryNameChar = QC.suchThat QC.arbitrary Name.isVarchar
 
 instance QC.Arbitrary Literal.Literal where
   arbitrary = Literal.Literal <$> QC.arbitrary

--- a/src/test/Main.hs
+++ b/src/test/Main.hs
@@ -11,7 +11,7 @@ module Main
 where
 
 import qualified Burrito
-import qualified Burrito.Type.Character as Character
+import qualified Burrito.Type.LitChar as LitChar
 import qualified Burrito.Type.Expression as Expression
 import qualified Burrito.Type.Literal as Literal
 import qualified Burrito.Type.Modifier as Modifier
@@ -1316,13 +1316,13 @@ instance QC.Arbitrary Literal.Literal where
   arbitrary = Literal.Literal <$> QC.arbitrary
   shrink = fmap Literal.Literal . QC.shrink . Literal.characters
 
-instance QC.Arbitrary Character.Character where
+instance QC.Arbitrary LitChar.LitChar where
   arbitrary = QC.oneof
-    [ Character.Encoded <$> QC.arbitrary
+    [ LitChar.Encoded <$> QC.arbitrary
     , do
-      char <- QC.suchThat QC.arbitrary Character.isLiteral
-      maybe QC.discard pure $ Character.makeUnencoded char
+      char <- QC.suchThat QC.arbitrary LitChar.isLiteral
+      maybe QC.discard pure $ LitChar.makeUnencoded char
     ]
   shrink character = case character of
-    Character.Encoded word8 -> Character.Encoded <$> QC.shrink word8
-    Character.Unencoded char -> Maybe.mapMaybe Character.makeUnencoded $ QC.shrink char
+    LitChar.Encoded word8 -> LitChar.Encoded <$> QC.shrink word8
+    LitChar.Unencoded char -> Maybe.mapMaybe LitChar.makeUnencoded $ QC.shrink char

--- a/src/test/Main.hs
+++ b/src/test/Main.hs
@@ -1322,48 +1322,8 @@ instance QC.Arbitrary Literal.Literal where
 instance QC.Arbitrary Character.Character where
   arbitrary = QC.oneof
     [ Character.Encoded <$> QC.arbitrary
-    , Character.Unencoded <$> arbitraryLiteralChar
+    , Character.Unencoded <$> QC.suchThat QC.arbitrary Character.isLiteral
     ]
   shrink character = case character of
     Character.Encoded word8 -> Character.Encoded <$> QC.shrink word8
-    Character.Unencoded char -> fmap Character.Unencoded . filter isLiteralChar $ QC.shrink char
-
--- TODO: deduplicate with `isLiteral`
-arbitraryLiteralChar :: QC.Gen Char
-arbitraryLiteralChar = QC.suchThat QC.arbitrary isLiteralChar
-
-isLiteralChar :: Char -> Bool
-isLiteralChar x = case x of
-  ' ' -> False
-  '"' -> False
-  '\'' -> False
-  '%' -> False
-  '<' -> False
-  '>' -> False
-  '\\' -> False
-  '^' -> False
-  '`' -> False
-  '{' -> False
-  '|' -> False
-  '}' -> False
-  _ -> '\x20' <= x && x <= '\x7e'
-    || '\xa0' <= x && x <= '\xd7ff'
-    || '\xf900' <= x && x <= '\xfdcf'
-    || '\xfdf0' <= x && x <= '\xffef'
-    || '\x10000' <= x && x <= '\x1fffd'
-    || '\x20000' <= x && x <= '\x2fffd'
-    || '\x30000' <= x && x <= '\x3fffd'
-    || '\x40000' <= x && x <= '\x4fffd'
-    || '\x50000' <= x && x <= '\x5fffd'
-    || '\x60000' <= x && x <= '\x6fffd'
-    || '\x70000' <= x && x <= '\x7fffd'
-    || '\x80000' <= x && x <= '\x8fffd'
-    || '\x90000' <= x && x <= '\x9fffd'
-    || '\xa0000' <= x && x <= '\xafffd'
-    || '\xb0000' <= x && x <= '\xbfffd'
-    || '\xc0000' <= x && x <= '\xcfffd'
-    || '\xd0000' <= x && x <= '\xdfffd'
-    || '\xe1000' <= x && x <= '\xefffd'
-    || '\xe000' <= x && x <= '\xf8ff'
-    || '\xf0000' <= x && x <= '\xffffd'
-    || '\x100000' <= x && x <= '\x10fffd'
+    Character.Unencoded char -> fmap Character.Unencoded . filter Character.isLiteral $ QC.shrink char


### PR DESCRIPTION
Fixes #6. 

An example is worth a thousand words:

``` hs
>>> render [uriTemplate|http://example/search{?query}|]
"http://example/search{?query}"
```

This PR adds `render`, a new function that outputs a URI template in its canonical form without attempting to do any expansion. This could be used for generating documentation, showing templates to users, or just poking around with templates in the REPL. 

This PR also does a bunch of housekeeping stuff in service of implementing round trip property tests. These already caught one bug, which was fixed in 07aeac7.