### PR TITLE
Use `render` to implement an instance for `Show`

### DIFF
--- a/src/lib/Burrito.hs
+++ b/src/lib/Burrito.hs
@@ -33,6 +33,7 @@ module Burrito
   , Match.match
   , TH.uriTemplate
   , Template.Template
+  , Template.render
   , Value.Value
   , stringValue
   , listValue

--- a/src/lib/Burrito.hs
+++ b/src/lib/Burrito.hs
@@ -28,12 +28,12 @@
 -- In short, use @parse@ to parse templates and @expand@ to render them.
 module Burrito
   ( Parse.parse
+  , Template.render
   , Expand.expand
   , Expand.expandWith
   , Match.match
   , TH.uriTemplate
   , Template.Template
-  , Template.render
   , Value.Value
   , stringValue
   , listValue

--- a/src/lib/Burrito.hs
+++ b/src/lib/Burrito.hs
@@ -28,7 +28,6 @@
 -- In short, use @parse@ to parse templates and @expand@ to render them.
 module Burrito
   ( Parse.parse
-  , Render.render
   , Expand.expand
   , Expand.expandWith
   , Match.match
@@ -44,7 +43,6 @@ where
 import qualified Burrito.Internal.Expand as Expand
 import qualified Burrito.Internal.Match as Match
 import qualified Burrito.Internal.Parse as Parse
-import qualified Burrito.Internal.Render as Render
 import qualified Burrito.Internal.TH as TH
 import qualified Burrito.Internal.Type.Template as Template
 import qualified Burrito.Internal.Type.Value as Value

--- a/src/lib/Burrito/Internal/Render.hs
+++ b/src/lib/Burrito/Internal/Render.hs
@@ -12,7 +12,6 @@ import qualified Burrito.Internal.Type.MaxLength as MaxLength
 import qualified Burrito.Internal.Type.Modifier as Modifier
 import qualified Burrito.Internal.Type.Name as Name
 import qualified Burrito.Internal.Type.Operator as Operator
-import qualified Burrito.Internal.Type.Template as Template
 import qualified Burrito.Internal.Type.Token as Token
 import qualified Burrito.Internal.Type.Variable as Variable
 import qualified Data.List as List
@@ -20,23 +19,8 @@ import qualified Data.List.NonEmpty as NonEmpty
 import qualified Data.Text.Lazy as LazyText
 import qualified Data.Text.Lazy.Builder as Builder
 
--- | Renders a template back into a string. This is essentially the opposite of
--- @parse@. Usually you'll want to use @expand@ to actually substitute
--- variables in the template, but this can be useful for printing out the
--- template itself
---
--- >>> render <$> parse "valid-template"
--- Just "valid-template"
--- >>> render <$> parse "{var}"
--- Just "{var}"
-render :: Template.Template -> String
-render = builderToString . template
-
 builderToString :: Builder.Builder -> String
 builderToString = LazyText.unpack . Builder.toLazyText
-
-template :: Template.Template -> Builder.Builder
-template = foldMap token . Template.tokens
 
 token :: Token.Token -> Builder.Builder
 token x = case x of

--- a/src/lib/Burrito/Internal/Type/Template.hs
+++ b/src/lib/Burrito/Internal/Type/Template.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 
-module Burrito.Internal.Type.Template (Template (..)) where
+module Burrito.Internal.Type.Template (Template(..)) where
 
 import qualified Burrito.Internal.Render as Render
 import qualified Burrito.Internal.Type.Token as Token

--- a/src/lib/Burrito/Internal/Type/Template.hs
+++ b/src/lib/Burrito/Internal/Type/Template.hs
@@ -10,8 +10,7 @@ import qualified Data.Text.Lazy.Builder as Builder
 -- | Represents a URI template.
 newtype Template = Template
   { tokens :: [Token.Token]
-  }
-  deriving (Data.Data, Eq, Ord)
+  } deriving (Data.Data, Eq, Ord)
 
 instance Show Template where
   show = render

--- a/src/lib/Burrito/Internal/Type/Template.hs
+++ b/src/lib/Burrito/Internal/Type/Template.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 
-module Burrito.Internal.Type.Template (Template(..)) where
+module Burrito.Internal.Type.Template (Template (..), render) where
 
 import qualified Burrito.Internal.Render as Render
 import qualified Burrito.Internal.Type.Token as Token

--- a/src/lib/Burrito/Internal/Type/Template.hs
+++ b/src/lib/Burrito/Internal/Type/Template.hs
@@ -1,11 +1,32 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 
-module Burrito.Internal.Type.Template (Template(..)) where
+module Burrito.Internal.Type.Template (Template (..)) where
 
+import qualified Burrito.Internal.Render as Render
 import qualified Burrito.Internal.Type.Token as Token
 import qualified Data.Data as Data
+import qualified Data.Text.Lazy.Builder as Builder
 
 -- | Represents a URI template.
 newtype Template = Template
   { tokens :: [Token.Token]
-  } deriving (Data.Data, Eq, Ord, Show)
+  }
+  deriving (Data.Data, Eq, Ord)
+
+instance Show Template where
+  show = render
+
+-- | Renders a template back into a string. This is essentially the opposite of
+-- @parse@. Usually you'll want to use @expand@ to actually substitute
+-- variables in the template, but this can be useful for printing out the
+-- template itself
+--
+-- >>> render <$> parse "valid-template"
+-- Just "valid-template"
+-- >>> render <$> parse "{var}"
+-- Just "{var}"
+render :: Template -> String
+render = Render.builderToString . template
+
+template :: Template -> Builder.Builder
+template = foldMap Render.token . tokens

--- a/src/test/Main.hs
+++ b/src/test/Main.hs
@@ -167,7 +167,7 @@ main = Hspec.hspec . Hspec.describe "Burrito" $ do
     . Hspec.it "round trips"
     . QC.property
     $ \(Template template) ->
-        Burrito.parse (Burrito.render template) == Just template
+        Burrito.parse (show template) == Just template
 
 -- brittany-next-binding --columns 160
 tests :: [Test]
@@ -1169,7 +1169,7 @@ runTest test =
         values = testValues test
         actual = Burrito.expand values template
       actual `Hspec.shouldBe` expected
-      Burrito.parse (Burrito.render template) `Hspec.shouldBe` Just template
+      Burrito.parse (show template) `Hspec.shouldBe` Just template
       let
         relevant =
           List.sort $ keepRelevant (templateVariables template) values
@@ -1261,7 +1261,7 @@ newtype Template = Template
 
 instance Show Template where
   show (Template template) =
-    unwords [show $ Burrito.render template, "{-", show template, "-}"]
+    unwords [show $ show template, "{-", show (Template.tokens template), "-}"]
 
 instance QC.Arbitrary Template where
   arbitrary = Template <$> arbitraryTemplate


### PR DESCRIPTION
This is a first, naive solution for #12. (less naive than just putting an orphan instance in `Burrito.Internal.Render`).

Baiscally I just moved the two functions in `Burrito.Internal.Render` that had a dependency to `Burrito.Internal.Type.Template` over to `Burrito.Internal.Type.Template` and fixed compile errors. The tests are green, and `show` does what I would expect.

I'm not entirely convinced that this is a good solution. In terms of cohesion, the functions I moved should reside in `Render`. I just moved them over to avoid the cyclic dependency.

What do you think about this?