### PR TITLE
Add support for GHC 9.2

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,30 @@
+ARG UBUNTU_TAG=20.04
+FROM ubuntu:"$UBUNTU_TAG"
+
+ENV LANG=C.UTF-8
+RUN \
+  apt-get update && \
+  apt-get install --assume-yes curl gcc git libgmp-dev nano make sudo
+
+ARG GHCUP_VERSION=0.1.17.4
+RUN \
+  curl --output /usr/local/bin/ghcup "https://downloads.haskell.org/~ghcup/$GHCUP_VERSION/x86_64-linux-ghcup-$GHCUP_VERSION" && \
+  chmod +x /usr/local/bin/ghcup && \
+  ghcup --version
+
+ARG USER_NAME=haskell
+RUN \
+  useradd --create-home --shell "$( which bash )" "$USER_NAME" && \
+  echo "$USER_NAME ALL=(ALL) NOPASSWD: ALL" | tee "/etc/sudoers.d/$USER_NAME"
+USER "$USER_NAME"
+ENV PATH="/home/$USER_NAME/.cabal/bin:/home/$USER_NAME/.ghcup/bin:$PATH"
+
+ARG GHC_VERSION=9.2.1
+RUN \
+  ghcup install ghc "$GHC_VERSION" --set && \
+  ghc --version
+
+ARG CABAL_VERSION=3.6.2.0
+RUN \
+  ghcup install cabal "$CABAL_VERSION" --set && \
+  cabal --version

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,6 @@
+{
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "postCreateCommand": "cabal update"
+}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,11 +14,12 @@ jobs:
     strategy:
       matrix:
         include:
-          - { os: ubuntu-18.04, ghc: 9.0.1, cabal: 3.4.0.0 }
-          - { os: ubuntu-18.04, ghc: 8.10.3, cabal: 3.2.0.0 }
-          - { os: macos-10.15, ghc: 8.10.3, cabal: 3.2.0.0 }
-          - { os: windows-2019, ghc: 8.10.3, cabal: 3.2.0.0 }
-          - { os: ubuntu-18.04, ghc: 8.8.4, cabal: 3.0.0.0 }
+          - { os: ubuntu-20.04, ghc: 9.2.1 }
+          - { os: ubuntu-20.04, ghc: 9.0.1 }
+          - { os: ubuntu-20.04, ghc: 8.10.7 }
+          - { os: macos-11, ghc: 9.2.1 }
+          - { os: windows-2019, ghc: 9.2.1 }
+          - { os: ubuntu-20.04, ghc: 8.8.4 }
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -26,21 +27,22 @@ jobs:
         uses: haskell/actions/setup@v1
         with:
           ghc-version: ${{ matrix.ghc }}
-          cabal-version: ${{ matrix.cabal }}
-      - run: cabal freeze && cat cabal.project.freeze
+          cabal-version: 3.6.2.0
+      - run: cabal configure --enable-tests --flags pedantic --jobs --test-show-details direct
+      - run: cabal freeze
+      - run: cat cabal.project.freeze
       - uses: actions/cache@v2
         with:
           path: ${{ steps.setup-haskell.outputs.cabal-store }}
-          key: ${{ matrix.os }}-${{ matrix.ghc }}-${{ matrix.cabal }}-${{ hashFiles('cabal.project.freeze') }}
-          restore-keys: |
-            ${{ matrix.os }}-${{ matrix.ghc }}-${{ matrix.cabal }}-
-            ${{ matrix.os }}-${{ matrix.ghc }}-
-      - run: cabal test --test-show-details direct
+          key: ${{ matrix.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}
+          restore-keys: ${{ matrix.os }}-${{ matrix.ghc }}-
+      - run: cabal build
+      - run: cabal test
       - run: cabal sdist
       - uses: actions/upload-artifact@v2
         with:
           path: dist-newstyle/sdist/burrito-*.tar.gz
           name: burrito-${{ github.sha }}.tar.gz
       - run: cabal check
-      - if: github.event_name == 'release' && matrix.os == 'ubuntu-18.04' && matrix.ghc == '9.0.1'
+      - if: github.event_name == 'release' && matrix.os == 'ubuntu-20.04' && matrix.ghc == '9.0.1'
         run: cabal upload --publish --username '${{ secrets.HACKAGE_USERNAME }}' --password '${{ secrets.HACKAGE_PASSWORD }}' dist-newstyle/sdist/burrito-*.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /.stack-work/
 /.vscode/
+/cabal.project.local*
+/dist-newstyle/
 /stack.yaml.lock

--- a/burrito.cabal
+++ b/burrito.cabal
@@ -32,13 +32,18 @@ source-repository head
   location: https://github.com/tfausak/burrito
   type: git
 
+flag pedantic
+  default: False
+  description: Enables @-Werror@, which turns warnings into errors.
+  manual: True
+
 library
   build-depends:
-    base >= 4.13.0 && < 4.16
+    base >= 4.13.0 && < 4.17
     , bytestring >= 0.10.10 && < 0.12
     , containers >= 0.6.2 && < 0.7
     , parsec >= 3.1.14 && < 3.2
-    , template-haskell >= 2.15.0 && < 2.18
+    , template-haskell >= 2.15.0 && < 2.19
     , text >= 1.2.4 && < 1.3
     , transformers >= 0.5.6 && < 0.6
   default-language: Haskell2010
@@ -70,12 +75,21 @@ library
     -Wno-missing-deriving-strategies
     -Wno-missing-exported-signatures
     -Wno-safe
+    -Wno-missed-specialisations
+    -Wno-all-missed-specialisations
   hs-source-dirs: src/lib
+
+  if flag(pedantic)
+    ghc-options: -Werror
 
   if impl(ghc >= 8.10)
     ghc-options:
       -Wno-missing-safe-haskell-mode
       -Wno-prepositive-qualified-module
+
+  if impl(ghc >= 9.2)
+    ghc-options:
+      -Wno-missing-kind-signatures
 
 test-suite test
   build-depends:


### PR DESCRIPTION
Also:

- Set up a development container. 
- Test against GHC 8.10.7.
- Use Cabal 3.6.2.0 for all CI builds. 
- Upgrade to Ubuntu 20.04. 
- Add `pedantic` flag and enable it in CI. 