### PR TITLE
Allow QuickCheck 2.16

### DIFF
--- a/burrito.cabal
+++ b/burrito.cabal
@@ -103,7 +103,7 @@ library
 test-suite burrito-test-suite
   import: executable
   build-depends:
-    QuickCheck ^>=2.14.3 || ^>=2.15,
+    QuickCheck ^>=2.14.3 || ^>=2.15 || ^>=2.16,
     containers,
     hspec ^>=2.11.8,
     text,


### PR DESCRIPTION
https://github.com/commercialhaskell/stackage/issues/7778

Seems like there were not actually any breaking changes: https://github.com/nick8325/quickcheck/compare/2.15.0.1...2.16